### PR TITLE
Clear kubectl resolv-conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Debian stable amd64
   `bind-address`, `tls-san`, etc. should be set separately.
 + `k3s_iptables`: list of additional firewall rules for `k3s_interface`.
 + `k3s_version` (default: latest Github release): which version to install.
++ `k3s_resolv_conf` (default: /dev/null): path to file to use instead of 
+  `/etc/resolv.conf` for kubelet.  An empty resolv.conf removes the
+  host's domain from the DNS search path, which is useful to workaround
+  an [issue with CloudFlare DNS](https://github.com/ho-ansible/k3s/issues/6)
+  with non-existent names on a DNSSEC-enabled domain.
 
 ### Managed Variables
 + `k3s_token`: auto-generated if not present, and stored in a group var

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ k3s_interface: "{{ ansible_default_ipv4.interface }}"
 k3s_iptables: []
 
 k3s_version: "{{ (lookup('url', k3s_latest_url) | from_json).name }}"
+k3s_resolv_conf: /dev/null

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -12,4 +12,5 @@ token: "{{ k3s_token }}"
 node-label: {{ label }}
 {% endfor %}
 flannel-iface: {{ k3s_interface }}
+resolv-conf: {{ k3s_resolv_conf }}
 {{ k3s_config | to_nice_yaml }}


### PR DESCRIPTION
in particular, clear the host's domain from the default DNS search path.

Closes #6 